### PR TITLE
Remove gcp and cloud region from kafka create (#1851)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@
   <img alt="Logo" src="https://user-images.githubusercontent.com/11743717/127519981-97c76ae4-f17b-4ac8-8b4d-365bfa4a6374.png">
 </p>
 
-`rhoas` is a command-line client for managing Red Hat application services
+`rhoas` is a command-line client for managing Red Hat OpenShift Application Services.
 
+**IMPORTANT:** This project is no longer active. The cloud services managed by the `rhoas` command are no longer available. For the latest self-managed alternatives, see the following products:
 
+* OpenShift Streams for Apache Kakfa: see [Red Hat Streams for Apache Kakfa](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/)
+* OpenShift Service Registry: see [Red Hat build of Apicurio Registry](https://access.redhat.com/documentation/en-us/red_hat_build_of_apicurio_registry)
+* OpenShift Connectors: see [Red Hat build of Apache Camel K](https://access.redhat.com/documentation/en-us/red_hat_build_of_apache_camel_k)
 
 ## Installing RHOAS
 

--- a/pkg/cmd/kafka/create/create.go
+++ b/pkg/cmd/kafka/create/create.go
@@ -54,6 +54,7 @@ const (
 	// FlagMarketPlace is a flag representing billing model of the instance
 	FlagBillingModel  = "billing-model"
 	TrialInstanceType = "Trial"
+	CloudProvider     = "aws"
 )
 
 type options struct {
@@ -572,19 +573,27 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		f.Logger.Info(opts.f.Localizer.MustLocalize("kafka.create.info.enterpriseQuota"))
 	}
 
+	if opts.useTrialFlow {
+		opts.f.Logger.Info(opts.f.Localizer.MustLocalize("kafka.create.usingTrialInstance"))
+	}
+
 	answers, err = promptForKafkaName(f, answers)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get the list of enterprise clusters in the users organization if there are any, creates a map of cluster ids
-	// to names to include names in the prompt
-	kfmClusterList, clusterMap, err := setEnterpriseClusterList(opts)
-	if err != nil {
-		return nil, err
+	opts.kfmClusterList = &kafkamgmtclient.EnterpriseClusterList{}
+
+	if opts.useEnterpriseFlow {
+		// Get the list of enterprise clusters in the users organization if there are any, creates a map of cluster ids
+		// to names to include names in the prompt
+		kfmClusterList, clusterMap, err2 := setEnterpriseClusterList(opts)
+		if err2 != nil {
+			return nil, err2
+		}
+		opts.kfmClusterList = kfmClusterList
+		opts.clusterMap = clusterMap
 	}
-	opts.kfmClusterList = kfmClusterList
-	opts.clusterMap = clusterMap
 
 	// If there are enterprise clusters in the user's organization, prompt them to select a flow (enterprise or legacy)
 	// using the interactive prompt. If there are no enterprise clusters, the user must use the legacy flow.
@@ -592,10 +601,6 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 	err = determineFlowFromQuota(opts)
 	if err != nil {
 		return nil, err
-	}
-
-	if opts.useTrialFlow {
-		opts.f.Logger.Info(opts.f.Localizer.MustLocalize("kafka.create.usingTrialInstance"))
 	}
 
 	if opts.useEnterpriseFlow {
@@ -638,12 +643,10 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 		}
 	}
 
-	// If the user is not using an enterprise cluster, prompt them to select a cloud provider
+	// If the user is not using an enterprise cluster, we set the cloud provider to aws as this is currently the only
+	// cloud provider that we support
 	if opts.useLegacyFlow {
-		answers, err = cloudProviderPrompt(f, answers)
-		if err != nil {
-			return nil, err
-		}
+		answers.CloudProvider = CloudProvider
 	}
 
 	// gets the billing model for the kafka, if the user has more than one billing model, a prompt is shown to select one
@@ -741,21 +744,18 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 			return nil, err
 		}
 
-		if len(regionIDs) == 0 {
+		// selecting the region, if there is only one region available, we skip the prompt
+		switch {
+		case len(regionIDs) == 0:
 			return nil, f.Localizer.MustLocalizeError("kafka.create.error.noRegionSupported")
+		case len(regionIDs) == 1:
+			answers.Region = regionIDs[0]
+		default:
+			err = promptForCloudRegion(f, regionIDs, answers)
+			if err != nil {
+				return nil, err
+			}
 		}
-
-		regionPrompt := &survey.Select{
-			Message: f.Localizer.MustLocalize("kafka.create.input.cloudRegion.message"),
-			Options: regionIDs,
-			Help:    f.Localizer.MustLocalize("kafka.create.input.cloudRegion.help"),
-		}
-
-		err = survey.AskOne(regionPrompt, &answers.Region)
-		if err != nil {
-			return nil, err
-		}
-
 		sizes, err = FetchValidKafkaSizes(opts.f, answers.CloudProvider, answers.Region, *userQuota)
 		if err != nil {
 			return nil, err
@@ -796,6 +796,20 @@ func promptKafkaPayload(opts *options, constants *remote.DynamicServiceConstants
 
 	}
 	return payload, nil
+}
+
+func promptForCloudRegion(f *factory.Factory, regionIDs []string, answers *promptAnswers) error {
+	regionPrompt := &survey.Select{
+		Message: f.Localizer.MustLocalize("kafka.create.input.cloudRegion.message"),
+		Options: regionIDs,
+		Help:    f.Localizer.MustLocalize("kafka.create.input.cloudRegion.help"),
+	}
+
+	err := survey.AskOne(regionPrompt, &answers.Region)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func getBillingModel(opts *options, orgQuota *accountmgmtutil.OrgQuotas, answers *promptAnswers) (*promptAnswers, error) {
@@ -937,29 +951,6 @@ func marketplaceQuotaPrompt(orgQuota *accountmgmtutil.OrgQuotas, answers *prompt
 	return answers, nil
 }
 
-func cloudProviderPrompt(f *factory.Factory, answers *promptAnswers) (*promptAnswers, error) {
-	cloudProviderNames, err := GetEnabledCloudProviderNames(f)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(cloudProviderNames) == 1 {
-		answers.CloudProvider = cloudProviderNames[0]
-		return answers, nil
-	}
-
-	cloudProviderPrompt := &survey.Select{
-		Message: f.Localizer.MustLocalize("kafka.create.input.cloudProvider.message"),
-		Options: cloudProviderNames,
-	}
-
-	err = survey.AskOne(cloudProviderPrompt, &answers.CloudProvider)
-	if err != nil {
-		return nil, err
-	}
-	return answers, nil
-}
-
 // This may need to altered as the `name` are mutable on ocm side
 func getClusterNameMap(opts *options, clusterList *kafkamgmtclient.EnterpriseClusterList) (*map[string]v1.Cluster, error) {
 	//	for each cluster in the list, get the name from ocm and add it to the cluster list
@@ -977,14 +968,17 @@ func getClusterNameMap(opts *options, clusterList *kafkamgmtclient.EnterpriseClu
 }
 
 func selectClusterPrompt(opts *options) (int, error) {
-	promptOptions := openshiftclustercmdutil.CreatePromptOptionsFromClusters(opts.kfmClusterList, opts.clusterMap)
+	promptOptions, err := openshiftclustercmdutil.CreatePromptOptionsFromClusters(opts.f, opts.kfmClusterList, opts.clusterMap)
+	if err != nil {
+		return 0, err
+	}
 	promptForCluster := &survey.Select{
 		Message: opts.f.Localizer.MustLocalize("kafka.create.input.cluster.selectClusterMessage"),
 		Options: *promptOptions,
 	}
 
 	var index int
-	err := survey.AskOne(promptForCluster, &index)
+	err = survey.AskOne(promptForCluster, &index)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/cmd/kafka/openshift-cluster/openshiftclustercmdutil/dedicated_util.go
+++ b/pkg/cmd/kafka/openshift-cluster/openshiftclustercmdutil/dedicated_util.go
@@ -42,15 +42,18 @@ func (v *Validator) ValidatorForMachinePoolNodes(val interface{}) error {
 	return nil
 }
 
-func CreatePromptOptionsFromClusters(clusterList *kafkamgmtclient.EnterpriseClusterList, clusterMap *map[string]v1.Cluster) *[]string {
+func CreatePromptOptionsFromClusters(f *factory.Factory, clusterList *kafkamgmtclient.EnterpriseClusterList, clusterMap *map[string]v1.Cluster) (*[]string, error) {
 	promptOptions := []string{}
 	validatedClusters := ValidateClusters(clusterList)
+	if len(validatedClusters.Items) == 0 {
+		return &promptOptions, f.Localizer.MustLocalizeError("kafka.cluster.common.error.noClustersAvailable")
+	}
 	for _, cluster := range validatedClusters.Items {
 		ocmCluster := (*clusterMap)[cluster.GetId()]
 		display := ocmCluster.Name() + " (" + cluster.GetId() + ")"
 		promptOptions = append(promptOptions, display)
 	}
-	return &promptOptions
+	return &promptOptions, nil
 }
 
 func ValidateClusters(clusterList *kafkamgmtclient.EnterpriseClusterList) *kafkamgmtclient.EnterpriseClusterList {

--- a/pkg/core/localize/locales/en/cmd/kafka.en.toml
+++ b/pkg/core/localize/locales/en/cmd/kafka.en.toml
@@ -1229,3 +1229,5 @@ You do not have enough quota to create a Kafka instance on your own OpenShift Cl
 
 Please visit https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-streams-for-apache-kafka/pricing to request more quota.
 '''
+[kafka.cluster.common.error.noClustersAvailable]
+one = 'no registered OpenShift clusters found, an OpenShit cluster must be registered to use the service'


### PR DESCRIPTION
* refactor: remove gcp and cloud region from kafka create

* refactor: better error message when the user has enterprise quota but doesn't have any registered clusters

* refactor: using localizer for error

<!-- Add a description here or link to the relevant GitHub issue
See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue on how to link an issue -->

Closes # <!-- If there is no issue to link, you can remove this -->

### Verification Steps
<!-- Add verification steps here if applicable. Remove this section if it does not apply -->
1. Do x
2. Do y

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change
- [ ] Other (please specify)
